### PR TITLE
Remove the ELRS handset address distinction

### DIFF
--- a/src/SCRIPTS/CRSFSimulator/csrfsimulator.lua
+++ b/src/SCRIPTS/CRSFSimulator/csrfsimulator.lua
@@ -99,7 +99,6 @@ local CRSF = {
   ADDRESS_HANDSET = 0xEA, -- EdgeTX's official handset address
   ADDRESS_RX = 0xEC,
   ADDRESS_TX = 0xEE,
-  ADDRESS_HANDSET_ELRS = 0xEF, -- ELRS-custom Lua device address, not standard CRSF
 
   -- Field types0
   UINT8 = 0,

--- a/src/SCRIPTS/ELRS/crsf.lua
+++ b/src/SCRIPTS/ELRS/crsf.lua
@@ -27,7 +27,6 @@ CRSF.CONST = {
   ADDRESS_HANDSET = 0xEA, -- EdgeTX's official handset address
   ADDRESS_RX = 0xEC,
   ADDRESS_TX = 0xEE,
-  ADDRESS_HANDSET_ELRS = 0xEF, -- ELRS-custom Lua device address, not standard CRSF
 
   -- Frame types
   FRAMETYPE_DEVICE_PING = 0x28,
@@ -257,10 +256,10 @@ function CRSF:decodeElrsStatus(data)
   }
 end
 
---- ELRS 1.x signature: an inbound PARAMETER_WRITE addressed to the official
--- handset address from the TX module. 3.x+ answers on ADDRESS_HANDSET_ELRS and
--- never writes to the handset. Reads data[1] (the destination) deliberately --
--- unlike the decoders above, which leave gating on the source to the caller.
+--- ELRS 1.x signature: an inbound PARAMETER_WRITE addressed to the handset
+-- from the TX module; 3.x+ never writes to the handset. Reads data[1] (the
+-- destination) deliberately -- unlike the decoders above, which leave gating
+-- on the source to the caller.
 -- @param data  array of byte values
 -- @return true when the frame matches the 1.x signature, nil otherwise
 function CRSF:isElrsV1Frame(data)
@@ -280,7 +279,7 @@ end
 --- Request ELRS status from the TX module (PARAMETER_WRITE with fieldId=0).
 -- The module answers with an ELRS_STATUS frame carrying its warning flags.
 function CRSF:requestElrsStatus()
-  CRSF.push(CRSF.CONST.FRAMETYPE_PARAMETER_WRITE, { CRSF.CONST.ADDRESS_TX, CRSF.CONST.ADDRESS_HANDSET_ELRS, 0, 0 })
+  CRSF.push(CRSF.CONST.FRAMETYPE_PARAMETER_WRITE, { CRSF.CONST.ADDRESS_TX, CRSF.CONST.ADDRESS_HANDSET, 0, 0 })
 end
 
 --- Send a COMMAND bind request. Addressed to the TX module it enters bind

--- a/src/SCRIPTS/ELRS/crsf_session.lua
+++ b/src/SCRIPTS/ELRS/crsf_session.lua
@@ -36,7 +36,7 @@ CRSFSession.__index = CRSFSession
 --- Create a session.
 -- @param opts  table with:
 --   deviceId          target device address (default ADDRESS_TX)
---   handsetId         reply-to address (default ADDRESS_HANDSET_ELRS)
+--   handsetId         reply-to address (default ADDRESS_HANDSET)
 --   responseTimeout   fixed read-retry deadline in ticks; when omitted it is
 --                     derived per device: 50 for the local ELRS TX, 500 for
 --                     remote devices relayed over the air link
@@ -56,7 +56,7 @@ function CRSFSession.new(opts)
   return setmetatable({
     -- Public facts
     deviceId = opts.deviceId or crsf.CONST.ADDRESS_TX,
-    handsetId = opts.handsetId or crsf.CONST.ADDRESS_HANDSET_ELRS,
+    handsetId = opts.handsetId or crsf.CONST.ADDRESS_HANDSET,
     deviceName = nil,
     isElrsTx = nil,
     fieldsCount = 0,
@@ -137,7 +137,6 @@ function CRSFSession:setDevice(device)
   self.deviceName = device.name
   self.fieldsCount = device.fieldCount
   self.isElrsTx = device.isElrs and device.id == crsf.CONST.ADDRESS_TX or nil
-  self.handsetId = self.isElrsTx and crsf.CONST.ADDRESS_HANDSET_ELRS or crsf.CONST.ADDRESS_HANDSET
   local st = self.status
   st.flags = 0
   st.connected = nil
@@ -669,9 +668,8 @@ function CRSFSession:tick()
 
   if self._trackStatus and now > self._nextStatusAt then
     if self.isElrsTx then
-      -- isElrsTx guarantees deviceId/handsetId are ADDRESS_TX and
-      -- ADDRESS_HANDSET_ELRS here (see setDevice), the addressing
-      -- requestElrsStatus() hardcodes.
+      -- isElrsTx guarantees deviceId is ADDRESS_TX here (see setDevice),
+      -- the addressing requestElrsStatus() hardcodes.
       crsf:requestElrsStatus()
     else
       self.status.receivedPackets = nil


### PR DESCRIPTION
Fixes #12

ExpressLRS/ExpressLRS#3680 (4.1) removed the special Lua address 0xEF from
the firmware together with the Bad/Good parameter it existed for. The
package still asks the ELRS TX as 0xEF and every other device as 0xEA.

Use the standard handset address 0xEA for everything, like the r18 lua:
drop the constant and the per-device switch in setDevice, and send the
status request as 0xEA as well.

As with the r18 lua, modules older than 4.1 now show their static Bad/Good
info row; the counts in the header keep updating as before. The 1.x
detection is unaffected: 3.x+ firmware never writes to the handset, and
the r18 lua already runs the same check on 0xEA.

Checked against the CRSFSimulator (all frames carry 0xEA, loading and
commands unchanged) and on a TX15 and a Boxer with 4.1.x modules.
