### PR TITLE
Gate ELRS modules below the 3.5.4 minimum

### DIFF
--- a/src/SCRIPTS/CRSFSimulator/csrfsimulator.lua
+++ b/src/SCRIPTS/CRSFSimulator/csrfsimulator.lua
@@ -54,6 +54,9 @@ local shim = loadScript("/SCRIPTS/CRSFSimulator/shim.lua")()
 --                    in minimized widgets, full-screen subtitle updates).
 --   "no_module"      No CRSF module found at all. Triggers the "No Module
 --                    Found" error dialog immediately.
+--   "old_firmware"   TX reports ExpressLRS 3.4.2, below the tool's 3.5.4
+--                    minimum. Triggers the unsupported-firmware screen
+--                    instead of the parameter list.
 --   "critical_error" TX + RX connected but the module reports a critical
 --                    error (baud rate too low). Exercises the warning screen
 --                    and the suppress-critical-errors write (field id 0x2E),
@@ -498,7 +501,7 @@ local txDevice = {
   name = "TX16S MK3",
   serialNo = CRSF.ELRS_SERIAL_ID,
   hwVer = 0,
-  swVer = 0x00030500, -- 3.5.0
+  swVer = config.scenario == "old_firmware" and 0x00030402 or 0x00040100, -- 3.4.2 / 4.1.0
   fieldCount = 25, -- total parameter count
   params = {
     {
@@ -722,7 +725,7 @@ local rxDevice = {
   name = "Bob 2400RX",
   serialNo = CRSF.ELRS_SERIAL_ID,
   hwVer = 0,
-  swVer = 0x00030500, -- 3.5.0
+  swVer = 0x00040100, -- 4.1.0
   fieldCount = 25, -- total parameter count
   params = {
     {

--- a/src/SCRIPTS/ELRS/crsf_session.lua
+++ b/src/SCRIPTS/ELRS/crsf_session.lua
@@ -67,6 +67,7 @@ function CRSFSession.new(opts)
     -- Read-and-clear flags for the app
     fieldHiddenChanged = nil,
     v1Detected = nil,
+    unsupportedElrs = nil, -- version string of an ELRS TX too old to browse
     -- Reassembly state (crsf_params.lua manages it; rx.chunk is readable)
     rx = { chunk = 0, expect = -1 },
 
@@ -185,6 +186,22 @@ function CRSFSession:_onFrame(command, data)
   end
 end
 
+-- The one home of the minimum ExpressLRS firmware: 3.5.4. Older modules
+-- predate the spec-compliant folders of ExpressLRS #3123 and cannot be
+-- browsed, so the session latches .unsupportedElrs instead of loading
+-- garbage (Lua-Scripts #11).
+local function elrsVersionOk(info)
+  if info.vMaj >= 4 then
+    return true
+  elseif info.vMaj == 3 and info.vMin > 5 then
+    return true
+  elseif info.vMaj == 3 and info.vMin == 5 and info.vRev >= 4 then
+    return true
+  end
+
+  return false
+end
+
 function CRSFSession:_onDeviceInfo(data)
   local info = crsf:decodeDeviceInfo(data)
   if not info then
@@ -199,6 +216,9 @@ function CRSFSession:_onDeviceInfo(data)
   device.name = info.name
   device.fieldCount = info.fieldCount
   device.isElrs = info.isElrs
+  if device.isElrs and device.id == crsf.CONST.ADDRESS_TX and not elrsVersionOk(info) then
+    self.unsupportedElrs = info.vMaj .. "." .. info.vMin .. "." .. info.vRev
+  end
   if self._onDeviceUpdate then
     self._onDeviceUpdate(device, isNew)
   end

--- a/src/SCRIPTS/TOOLS/ExpressLRS/main.lua
+++ b/src/SCRIPTS/TOOLS/ExpressLRS/main.lua
@@ -178,8 +178,8 @@ local function run(event, touchState)
   session:drain()
   session:tick()
 
-  if session.v1Detected then
-    UI.handleUnsupported()
+  if session.v1Detected or session.unsupportedElrs then
+    UI.handleUnsupported(session.unsupportedElrs)
     return 0
   end
 

--- a/src/SCRIPTS/TOOLS/ExpressLRS/ui/lcd.lua
+++ b/src/SCRIPTS/TOOLS/ExpressLRS/ui/lcd.lua
@@ -135,10 +135,11 @@ end
 -- Interface: handleUnsupported
 -- ============================================================================
 
-function UI.handleUnsupported()
+-- oldVersion set means an ELRS module below the minimum; nil means 1.x.
+function UI.handleUnsupported(oldVersion)
   drawAlert("Unsupported Firmware", {
-    "ELRS 1.x firmware detected.",
-    "Please update to 3.x.",
+    oldVersion and ("ELRS " .. oldVersion .. " detected.") or "ELRS 1.x firmware detected.",
+    oldVersion and "Requires 3.5.4 or later." or "Please update to 3.x.",
   })
 end
 

--- a/src/SCRIPTS/TOOLS/ExpressLRS/ui/lvgl.lua
+++ b/src/SCRIPTS/TOOLS/ExpressLRS/ui/lvgl.lua
@@ -367,11 +367,13 @@ end
 -- Interface: handleUnsupported
 -- ============================================================================
 
-function UI.handleUnsupported()
+-- oldVersion set means an ELRS module below the minimum; nil means 1.x.
+function UI.handleUnsupported(oldVersion)
   if not UI.uiBuilt then
     Dialogs.showMessage({
       title = "Unsupported Firmware",
-      message = "ELRS 1.x firmware detected. Please update to 3.x.",
+      message = oldVersion and ("ELRS " .. oldVersion .. " detected. Requires 3.5.4 or later.")
+        or "ELRS 1.x firmware detected. Please update to 3.x.",
     })
     UI.uiBuilt = true
   end


### PR DESCRIPTION
Fixes #11

A module older than 3.5.4 predates the spec-compliant folders of
ExpressLRS/ExpressLRS#3123, which the parameter loader is built on. The
tool cannot browse such a module - as reported, it just sits at the
loading screen.

The DEVICE_INFO answer that discovery already gets carries the firmware
version, so gate there: when an ELRS TX reports something below 3.5.4,
show the existing unsupported-firmware screen with the actual version
("ELRS 3.4.2 detected. Requires 3.5.4 or later.") instead of starting
to load. Same pattern as the 1.x detection.

The simulator's fake devices advertised 3.5.0, which the gate would now
refuse - they report 4.1.0, and a new "old_firmware" scenario reports
3.4.2 to exercise the screen.

Checked in the CRSFSimulator: "old_firmware" shows the message, "normal"
loads as before. I could not test against a real 3.4.2 module.
